### PR TITLE
Support specifying graphite-web, carbon, whisper & statsd versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,13 @@ Build the image yourself.
 
 1. `git clone https://github.com/graphite-project/docker-graphite-statsd.git`
 1. `docker build -t graphiteapp/graphite-statsd .`
+
+Alternate versions can be specified via `--build-arg`:
+
+* `version` will set the version/branch used for graphite-web, carbon & whisper
+* `graphite_version`, `carbon_version` & `whisper_version` set the version/branch used for individual components
+* `statsd_version` sets the version/branch used for statsd (note statsd version is prefixed with v)
+
+To build an image from latest graphite master, run:
+
+`docker build -t graphiteapp/graphite-statsd . --build-arg version=master`

--- a/conf/etc/my_init.d/01_conf_init.sh
+++ b/conf/etc/my_init.d/01_conf_init.sh
@@ -12,7 +12,7 @@ graphite_conf_dir_contents=$(find /opt/graphite/conf -mindepth 1 -print -quit)
 graphite_webapp_dir_contents=$(find /opt/graphite/webapp/graphite -mindepth 1 -print -quit)
 graphite_storage_dir_contents=$(find /opt/graphite/storage -mindepth 1 -print -quit)
 if [[ -z $graphite_dir_contents ]]; then
-  git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
+  # git clone -b 1.0.2 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
   cd /usr/local/src/graphite-web && python ./setup.py install
 fi
 if [[ -z $graphite_storage_dir_contents ]]; then

--- a/conf/usr/local/bin/manage.sh
+++ b/conf/usr/local/bin/manage.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 PYTHONPATH=/opt/graphite/webapp django-admin.py syncdb --settings=graphite.settings
-PYTHONPATH=/opt/graphite/webapp django-admin.py update_users --settings=graphite.settings
+# PYTHONPATH=/opt/graphite/webapp django-admin.py update_users --settings=graphite.settings


### PR DESCRIPTION
This PR adds support for specifying the versions to be used for graphite-web, carbon, whisper and statsd.

It also fixes a couple of warnings during the build, and allows master to build properly by no longer overwriting `app_settings.py`.

It also no longer re-clones `/usr/local/src/graphite-web` if `/opt/graphite` is missing, since `/usr/local/src/graphite-web` will still be present.

Finally, it no longer runs `django-admin.py update_users`, which doesn't appear to do anything.