### PR TITLE
 Download all components before running the config steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ RUN pip install django==1.5.12\
 RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/graphite-web.git /usr/local/src/graphite-web
 WORKDIR /usr/local/src/graphite-web
 RUN python ./setup.py install
-ADD conf/opt/graphite/conf/*.conf /opt/graphite/conf/
-ADD conf/opt/graphite/webapp/graphite/local_settings.py /opt/graphite/webapp/graphite/local_settings.py
-ADD conf/opt/graphite/webapp/graphite/app_settings.py /opt/graphite/webapp/graphite/app_settings.py
-RUN python /opt/graphite/webapp/graphite/manage.py collectstatic --noinput
 
 # install whisper
 RUN git clone -b 0.9.15 --depth 1 https://github.com/graphite-project/whisper.git /usr/local/src/whisper
@@ -51,6 +47,14 @@ RUN python ./setup.py install
 
 # install statsd
 RUN git clone -b v0.7.2 https://github.com/etsy/statsd.git /opt/statsd
+
+# config graphite
+ADD conf/opt/graphite/conf/*.conf /opt/graphite/conf/
+ADD conf/opt/graphite/webapp/graphite/local_settings.py /opt/graphite/webapp/graphite/local_settings.py
+ADD conf/opt/graphite/webapp/graphite/app_settings.py /opt/graphite/webapp/graphite/app_settings.py
+RUN python /opt/graphite/webapp/graphite/manage.py collectstatic --noinput
+
+# config statsd
 ADD conf/opt/statsd/config.js /opt/statsd/config.js
 
 # config nginx


### PR DESCRIPTION
All steps that require the downloading of files should happen first,
given that Docker caches every step.

With this pull request, changes in the Graphite config won't require a re-download of Statsd when building the Docker image after the first time.