### PR TITLE
Remove /opt/graphite mount point

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ docker run -d\
 ```
 
 **Note**: The container will initialize properly if you mount empty volumes at
-          `/opt/graphite`, `/opt/graphite/conf`, `/opt/graphite/storage`, or `/opt/statsd`
+          `/opt/graphite/conf`, `/opt/graphite/storage`, or `/opt/statsd`.
 
 ## Memcached config
 


### PR DESCRIPTION
If /opt/graphite is mounted, then running the 
container results in an error during initialization.

Mounting conf and storage folders is the intended
way of externalizing data for the container and that works.