### PR TITLE
Update init script to account for new statsd tcp config.

### DIFF
--- a/conf/etc/my_init.d/01_conf_init.sh
+++ b/conf/etc/my_init.d/01_conf_init.sh
@@ -31,6 +31,6 @@ fi
 statsd_dir_contents=$(find /opt/statsd -mindepth 1 -print -quit)
 if [[ -z $statsd_dir_contents ]]; then
   git clone -b v0.8.0 https://github.com/etsy/statsd.git /opt/statsd
-  cp $conf_dir/opt/statsd/config_udp.js /opt/statsd/config.js
+  cp $conf_dir/opt/statsd/config_*.js /opt/statsd/
 fi
 


### PR DESCRIPTION
When mounting an empty volume into the container at /opt/statsd, the init
scripts only copy config_udp.js into /opt/statsd/config.js. This causes
an error with stats, which is expecting configs with protocol in the name,
and it prevents the new config_tcp.js from being installed.