### PR TITLE
Make destinations in relay-rules.conf match carbon.conf

### DIFF
--- a/conf/opt/graphite/conf/relay-rules.conf
+++ b/conf/opt/graphite/conf/relay-rules.conf
@@ -18,4 +18,4 @@
 # in the DESTINATIONS setting in the [relay] section
 [default]
 default = true
-destinations = 127.0.0.1:2004:a, 127.0.0.1:2104:b
+destinations = 127.0.0.1:2004


### PR DESCRIPTION
The carbon.conf file states that:

  If using RELAY_METHOD = rules, all destinations used in relay-rules.conf
  must be defined in this list

  DESTINATIONS = 127.0.0.1:2004

However, relay-rules.conf is shipped with a configuration for multiple
carbon cache instances:

  destinations = 127.0.0.1:2004:a, 127.0.0.1:2104:b

This patch retains the out of the box single carbon cache configuration
and ensures that both "destinations" definitions properly match.