### PR TITLE
Make CARBON_METRIC_INTERVAL match storage-schema.conf

### DIFF
--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -263,7 +263,7 @@ WHISPER_FALLOCATE_CREATE = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 
 # Enable AMQP if you want to receve metrics using an amqp broker
 # ENABLE_AMQP = False
@@ -449,7 +449,7 @@ USE_FLOW_CONTROL = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 #
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
@@ -570,7 +570,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False


### PR DESCRIPTION
The default CARBON_METRIC_INTERVAL is 60s, but the storage-schemas.conf
file distributed with the container specifies a minimum resolution of
10s. These should match.

In order to prevent breaking existing installations' whisper databases,
this patch updates CARBON_METRIC_INTERVAL. An alternate solution would
be to update the storage-schema.conf, but that would require deleting
existing whisper databases and restarting the system.