### PR TITLE
Fix incorrect port in GRAPHITE_URL configuration.

### DIFF
--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -303,7 +303,7 @@ WHISPER_FALLOCATE_CREATE = True
 # BIND_PATTERNS = #
 
 # URL of graphite-web instance, this is used to add incoming series to the tag database
-GRAPHITE_URL = http://127.0.0.1:80
+GRAPHITE_URL = http://127.0.0.1:8080
 
 # Tag update interval, this specifies how frequently updates to existing series will trigger
 # an update to the tag index, the default setting is once every 100 updates


### PR DESCRIPTION
The GRAPHITE_URL configuration in carbon.conf uses port 80, but the
graphite webapp provided in the container listens on port 8080. When
this setting is incorrect, carbon is unable to perform tagging of
incoming metrics with an error similar to the following:

  [console] Error tagging my.metric.name: Connection was refused by other side: 111: Connection refused.

This patch updates the configuration to use the proper port.