### PR TITLE
remove user/group setting in logrotate.d/graphite-statsd

### DIFF
--- a/conf/etc/logrotate.d/graphite-statsd
+++ b/conf/etc/logrotate.d/graphite-statsd
@@ -7,5 +7,4 @@
   delaycompress
   notifempty
   copytruncate
-  su root syslog
 }


### PR DESCRIPTION
the "su root syslog" setting cause the following error:
```
root@a126daf0125a:~# logrotate /etc/logrotate.d/graphite-statsd
error: /etc/logrotate.d/graphite-statsd:10 unknown group 'syslog'
error: found error in /var/log/*.log /var/log/*/*.log , skipping
```
Base on https://github.com/phusion/baseimage-docker/issues/338
There is no syslog group since 16.04