### PR TITLE
resolves pip failure ImportError: cannot import name main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN if [ ! -z "${CONTAINER_TIMEZONE}" ]; \
     fi
 
 # fix python dependencies (LTS Django)
-RUN pip install --upgrade pip && \
+RUN python -m pip install --upgrade pip && \
   pip install django==1.11.12
 
 ARG version=1.1.3


### PR DESCRIPTION
```
Installing collected packages: pip
  Found existing installation: pip 8.1.1
    Not uninstalling pip at /usr/lib/python2.7/dist-packages, outside environment /usr
Successfully installed pip-10.0.1
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
ImportError: cannot import name main
The command '/bin/sh -c pip install --upgrade pip &&   pip install django==1.11.12' returned a non-zero code: 1
```

see https://github.com/pypa/pip/issues/5240 for more info