### PR TITLE
Adding env. variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,15 @@ RUN if [ ! -z "${CONTAINER_TIMEZONE}" ]; \
 # fix python dependencies (LTS Django)
 RUN python3 -m pip install --upgrade virtualenv virtualenv-tools && \
   virtualenv /opt/graphite && \
+  . /opt/graphite/bin/activate && \
   python3 -m pip install --upgrade pip && \
   pip3 install django==1.11.15 && \
   pip3 install fadvise && \
   pip3 install msgpack-python && \
   pip3 install gunicorn && \
   pip3 install fadvise && \
-  pip3 install msgpack-python
+  pip3 install msgpack-python && \
+  pip3 install django-statsd-mozilla
 
 ARG version=1.1.4
 ARG whisper_version=${version}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,49 @@ Update the default Django admin user account. _The default is insecure._
 First login at: [http://localhost/account/login](http://localhost/account/login)
 Then update the root user's profile at: [http://localhost/admin/auth/user/1/](http://localhost/admin/auth/user/1/)
 
+## Tunables
+Additional environment variables can be set to adjust performance.
+
+* GRAPHITE_WSGI_PROCESSES: (4) the number of WSGI daemon processes that should be started
+* GRAPHITE_WSGI_THREADS: (2) the number of threads to be created to handle requests in each daemon process
+* GRAPHITE_WSGI_REQUEST_TIMEOUT: (65) maximum number of seconds that a request is allowed to run before the daemon process is restarted
+* GRAPHITE_WSGI_MAX_REQUESTS: (1000) limit on the number of requests a daemon process should process before it is shutdown and restarted.
+* GRAPHITE_WSGI_REQUEST_LINE: (0) The maximum size of HTTP request line in bytes.
+
+### Graphite-web 
+* GRAPHITE_SECRET_KEY: (UNSAFE_DEFAULT)  Set this to a long, random unique string to use as a secret key for this install
+* GRAPHITE_ALLOWED_HOSTS: (*) In Django 1.5+ set this to the list of hosts your graphite instances is accessible as. See: [https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS](https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS)
+* GRAPHITE_TIME_ZONE: (Etc/UTC) Set your local timezone
+* GRAPHITE_LOG_ROTATION: (true) rotate logs
+* GRAPHITE_LOG_ROTATION_COUNT: (1) number of logs to keep
+* GRAPHITE_LOG_RENDERING_PERFORMANCE: (true) log performance information
+* GRAPHITE_LOG_CACHE_PERFORMANCE: (true) log cache performance information
+* GRAPHITE_LOG_FILE_INFO: (info.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_EXCEPTION: (exception.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_CACHE: (cache.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_RENDERING: (rendering.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_INFO: (info.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_EXCEPTION: (exception.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_CACHE: (cache.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_RENDERING: (rendering.log), set to "-" for stdout/stderr
+* GRAPHITE_DEBUG: (false) Enable full debug page display on exceptions (Internal Server Error pages)
+* GRAPHITE_DEFAULT_CACHE_DURATION: (0) Duration to cache metric data and graphs
+* GRAPHITE_CARBONLINK_HOSTS: ('127.0.0.1:7002') List of carbonlink hosts
+* GRAPHITE_CARBONLINK_TIMEOUT: (1.0) Carbonlink request timeout
+* GRAPHITE_CARBONLINK_HASHING_TYPE: ('carbon_ch') Type of metric hashing function.
+* GRAPHITE_REPLICATION_FACTOR: (1) # The replication factor to use with consistent hashing. This should usually match the value configured in Carbon.
+* GRAPHITE_CLUSTER_SERVERS: ('') This should list of remote servers in the cluster. These servers must each have local access to metric data. Note that the first server to return a match for a query will be used. See [docs](https://graphite.readthedocs.io/en/latest/config-local-settings.html#cluster-configuration) for details.
+* GRAPHITE_USE_WORKER_POOL: (true) Creates a pool of worker threads to which tasks can be dispatched. This makes sense if there are multiple CLUSTER_SERVERS and/or STORAGE_FINDERS because then the communication with them can be parallelized.
+* GRAPHITE_POOL_WORKERS_PER_BACKEND: (8) The number of worker threads that should be created per backend server
+* GRAPHITE_POOL_WORKERS: (1) A baseline number of workers that should always be created
+* GRAPHITE_REMOTE_FIND_TIMEOUT: (30) Timeout for metric find requests
+* GRAPHITE_REMOTE_FETCH_TIMEOUT: (60) Timeout to fetch series data
+* GRAPHITE_REMOTE_RETRY_DELAY: (0) Time before retrying a failed remote webapp.
+* GRAPHITE_REMOTE_PREFETCH_DATA: (false) # set to True to fetch all metrics using a single http request per remote server instead of one http request per target, per remote server. # Especially useful when generating graphs with more than 4-5 targets or if there's significant latency between this server and the backends.
+* GRAPHITE_MAX_FETCH_RETRIES: (2) Number of retries for a specific remote data fetch
+* GRAPHITE_FIND_CACHE_DURATION: (0) Time to cache remote metric find results
+* GRAPHITE_STATSD_HOST: ("127.0.0.1") If set, django_statsd.middleware.GraphiteRequestTimingMiddleware and django_statsd.middleware.GraphiteMiddleware will be enabled.
+
 ## Change the Configuration
 
 Read up on Graphite's [post-install tasks](https://graphite.readthedocs.org/en/latest/install.html#post-install-tasks).

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_WSGI_REQUEST_LINE: (0) The maximum size of HTTP request line in bytes.
 
 ### Graphite-web 
-* GRAPHITE_SECRET_KEY: (UNSAFE_DEFAULT)  Set this to a long, random unique string to use as a secret key for this install
 * GRAPHITE_ALLOWED_HOSTS: (*) In Django 1.5+ set this to the list of hosts your graphite instances is accessible as. See: [https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS](https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS)
 * GRAPHITE_TIME_ZONE: (Etc/UTC) Set your local timezone
 * GRAPHITE_LOG_ROTATION: (true) rotate logs
@@ -128,7 +127,7 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_LOG_FILE_CACHE: (cache.log), set to "-" for stdout/stderr
 * GRAPHITE_LOG_FILE_RENDERING: (rendering.log), set to "-" for stdout/stderr
 * GRAPHITE_DEBUG: (false) Enable full debug page display on exceptions (Internal Server Error pages)
-* GRAPHITE_DEFAULT_CACHE_DURATION: (0) Duration to cache metric data and graphs
+* GRAPHITE_DEFAULT_CACHE_DURATION: (60) Duration to cache metric data and graphs
 * GRAPHITE_CARBONLINK_HOSTS: ('127.0.0.1:7002') List of carbonlink hosts
 * GRAPHITE_CARBONLINK_TIMEOUT: (1.0) Carbonlink request timeout
 * GRAPHITE_CARBONLINK_HASHING_TYPE: ('carbon_ch') Type of metric hashing function.

--- a/conf/etc/service/graphite/run
+++ b/conf/etc/service/graphite/run
@@ -2,4 +2,17 @@
 
 sv start nginx || exit 1
 source /opt/graphite/bin/activate
-export PYTHONPATH=/opt/graphite/webapp && exec /opt/graphite/bin/gunicorn wsgi --workers=4 --bind=0.0.0.0:8080 --log-file=/var/log/gunicorn.log --preload --pythonpath=/opt/graphite/webapp/graphite
+export GRAPHITE_WSGI_PROCESSES=${GRAPHITE_WSGI_PROCESSES:-4}
+export GRAPHITE_WSGI_THREADS=${GRAPHITE_WSGI_THREADS:-2}
+export GRAPHITE_WSGI_REQUEST_TIMEOUT=${GRAPHITE_WSGI_REQUEST_TIMEOUT:-65}
+export GRAPHITE_WSGI_REQUEST_LINE=${GRAPHITE_WSGI_REQUEST_LINE:-0}
+export GRAPHITE_WSGI_MAX_REQUESTS=${GRAPHITE_WSGI_MAX_REQUESTS:-1000}
+export PYTHONPATH=/opt/graphite/webapp && \
+exec /opt/graphite/bin/gunicorn wsgi --preload --pythonpath=/opt/graphite/webapp/graphite \
+    --workers=${GRAPHITE_WSGI_PROCESSES} \
+    --threads=${GRAPHITE_WSGI_THREADS} \
+    --limit-request-line=${GRAPHITE_WSGI_REQUEST_LINE} \
+    --max-requests=${GRAPHITE_WSGI_MAX_REQUESTS} \
+    --timeout=${GRAPHITE_WSGI_REQUEST_TIMEOUT} \
+    --bind=0.0.0.0:8080 \
+    --log-file=/var/log/gunicorn.log

--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -264,7 +264,7 @@ WHISPER_FALLOCATE_CREATE = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 
 # Enable AMQP if you want to receve metrics using an amqp broker
 # ENABLE_AMQP = False
@@ -486,7 +486,7 @@ USE_FLOW_CONTROL = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 #
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False

--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -137,7 +137,7 @@ CACHE_QUERY_PORT = 7002
 USE_FLOW_CONTROL = True
 
 # If enabled this setting is used to timeout metric client connection if no
-# metrics have been sent in specified time in seconds 
+# metrics have been sent in specified time in seconds
 #METRIC_CLIENT_IDLE_TIMEOUT = None
 
 # By default, carbon-cache will log every whisper update and cache hit.
@@ -198,6 +198,7 @@ WHISPER_AUTOFLUSH = False
 # allocation and zero-ing. Enabling this option may allow a large increase of
 # MAX_CREATES_PER_MINUTE. If enabled on an OS or filesystem that is unsupported
 # this option will gracefully fallback to standard POSIX file access methods.
+# If enabled, disables WHISPER_SPARSE_CREATE regardless of the value.
 WHISPER_FALLOCATE_CREATE = True
 
 # Enabling this option will cause Whisper to lock each Whisper file it writes
@@ -207,7 +208,7 @@ WHISPER_FALLOCATE_CREATE = True
 
 # On systems which has a large number of metrics, an amount of Whisper write(2)'s
 # pageback sometimes cause disk thrashing due to memory shortage, so that abnormal
-# disk reads occur. Enabling this option makes it possible to decrease useless 
+# disk reads occur. Enabling this option makes it possible to decrease useless
 # page cache memory by posix_fadvise(2) with POSIX_FADVISE_RANDOM option.
 # WHISPER_FADVISE_RANDOM = False
 
@@ -263,7 +264,7 @@ WHISPER_FALLOCATE_CREATE = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-CARBON_METRIC_INTERVAL = 10
+# CARBON_METRIC_INTERVAL = 60
 
 # Enable AMQP if you want to receve metrics using an amqp broker
 # ENABLE_AMQP = False
@@ -303,11 +304,28 @@ CARBON_METRIC_INTERVAL = 10
 # BIND_PATTERNS = #
 
 # URL of graphite-web instance, this is used to add incoming series to the tag database
-GRAPHITE_URL = http://127.0.0.1:8080
+# GRAPHITE_URL = http://127.0.0.1:80
+
+# Tag support, when enabled carbon will make HTTP calls to graphite-web to update the tag index
+# ENABLE_TAGS = True
 
 # Tag update interval, this specifies how frequently updates to existing series will trigger
 # an update to the tag index, the default setting is once every 100 updates
 # TAG_UPDATE_INTERVAL = 100
+
+# Tag hash filenames, this specifies whether tagged metric filenames should use the hash of the metric name
+# or a human-readable name, using hashed names avoids issues with path length when using a large number of tags
+# TAG_HASH_FILENAMES = True
+
+# Tag batch size, this specifies the maximum number of series to be sent to graphite-web in a single batch
+# TAG_BATCH_SIZE = 100
+
+# Tag queue size, this specifies the maximum number of series to be queued for sending to graphite-web
+# There are separate queues for new series and for updates to existing series
+# TAG_QUEUE_SIZE = 10000
+
+# Set to enable Sentry.io exception monitoring.
+# RAVEN_DSN='YOUR_DSN_HERE'.
 
 # To configure special settings for the carbon-cache instance 'b', uncomment this:
 #[cache:b]
@@ -354,7 +372,7 @@ REPLICATION_FACTOR = 1
 
 # For REPLICATION_FACTOR >=2, set DIVERSE_REPLICAS to True to guarantee replicas
 # across distributed hosts. With this setting disabled, it's possible that replicas
-# may be sent to different caches on the same host. This has been the default 
+# may be sent to different caches on the same host. This has been the default
 # behavior since introduction of 'consistent-hashing' relay method.
 # Note that enabling this on an existing pre-0.9.14 cluster will require rebalancing
 # your metrics across the cluster nodes using a tool like Carbonate.
@@ -382,6 +400,25 @@ DESTINATIONS = 127.0.0.1:2004
 # set to one of "line", "pickle", "udp" and "protobuf". This list can be
 # extended with CarbonClientFactory plugins and defaults to "pickle".
 # DESTINATION_PROTOCOL = pickle
+
+# This defines the wire transport, either none or ssl.
+# If SSL is used any TCP connection will be upgraded to TLS1.  The system's
+# trust authority will be used unless DESTINATION_SSL_CA is specified in
+# which case an alternative certificate authority chain will be used for
+# verifying the remote certificate.
+# To use SSL you'll need the cryptography, service_identity, and twisted >= 14
+# DESTINATION_TRANSPORT = none
+# DESTINATION_SSL_CA=/path/to/private-ca.crt
+
+# This allows to have multiple connections per destinations, this will
+# pool all the replicas of a single host in the same queue and distribute
+# points accross these replicas instead of replicating them.
+# The following example will balance the load between :0 and :1.
+## DESTINATIONS = foo:2001:0, foo:2001:1
+## RELAY_METHOD = rules
+# Note: this is currently incompatible with USE_RATIO_RESET which gets
+# disabled if  this option is enabled.
+# DESTINATIONS_POOL_REPLICAS = False
 
 # When using consistent hashing it sometime makes sense to make
 # the ring dynamic when you don't want to loose points when a
@@ -437,7 +474,7 @@ TIME_TO_DEFER_SENDING = 0.0001
 USE_FLOW_CONTROL = True
 
 # If enabled this setting is used to timeout metric client connection if no
-# metrics have been sent in specified time in seconds 
+# metrics have been sent in specified time in seconds
 #METRIC_CLIENT_IDLE_TIMEOUT = None
 
 # Set this to True to enable whitelisting and blacklisting of metrics in
@@ -449,7 +486,7 @@ USE_FLOW_CONTROL = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-CARBON_METRIC_INTERVAL = 10
+# CARBON_METRIC_INTERVAL = 60
 #
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False
@@ -484,6 +521,21 @@ MIN_RESET_RATIO=0.9
 # below (2*CARBON_METRIC_INTERVAL) + 1 second will result in a lot of
 # reset connections for no good reason.
 MIN_RESET_INTERVAL=121
+
+# Enable TCP Keep Alive (http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html).
+# Default settings will send a probe every 30s. Default is False.
+# TCP_KEEPALIVE=True
+# The interval between the last data packet sent (simple ACKs are not
+# considered data) and the first keepalive probe; after the connection is marked
+# to need keepalive, this counter is not used any further.
+# TCP_KEEPIDLE=10
+# The interval between subsequential keepalive probes, regardless of what
+# the connection has exchanged in the meantime.
+# TCP_KEEPINTVL=30
+# The number of unacknowledged probes to send before considering the connection
+# dead and notifying the application layer.
+# TCP_KEEPCNT=2
+
 
 [aggregator]
 LINE_RECEIVER_INTERFACE = 0.0.0.0
@@ -535,7 +587,7 @@ MAX_QUEUE_SIZE = 10000
 USE_FLOW_CONTROL = True
 
 # If enabled this setting is used to timeout metric client connection if no
-# metrics have been sent in specified time in seconds 
+# metrics have been sent in specified time in seconds
 #METRIC_CLIENT_IDLE_TIMEOUT = None
 
 # This defines the maximum "message size" between carbon daemons.
@@ -570,7 +622,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-CARBON_METRIC_INTERVAL = 10
+# CARBON_METRIC_INTERVAL = 60
 
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False

--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -304,7 +304,7 @@ WHISPER_FALLOCATE_CREATE = True
 # BIND_PATTERNS = #
 
 # URL of graphite-web instance, this is used to add incoming series to the tag database
-# GRAPHITE_URL = http://127.0.0.1:80
+GRAPHITE_URL = http://127.0.0.1:8080
 
 # Tag support, when enabled carbon will make HTTP calls to graphite-web to update the tag index
 # ENABLE_TAGS = True
@@ -622,7 +622,7 @@ MAX_AGGREGATION_INTERVALS = 5
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 
 # In order to turn off logging of successful connections for the line
 # receiver, set this to False

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -11,7 +11,7 @@ import os
 # install. This key is used for salting of hashes used in auth tokens,
 # CRSF middleware, cookie storage, etc. This should be set identically among
 # instances if used behind a load balancer.
-SECRET_KEY = os.environ.get('GRAPHITE_SECRET_KEY', "UNSAFE_DEFAULT")
+#SECRET_KEY = 'UNSAFE_DEFAULT'
 
 # In Django 1.5+ set this to the list of hosts your graphite instances is
 # accessible as. See:
@@ -65,7 +65,7 @@ DEBUG = os.environ.get("GRAPHITE_DEBUG", "false").lower() in ['1','true','yes']
 # to the cache duration for the results. This allows for larger queries to be
 # cached for longer periods of times. All times are in seconds. If the policy is
 # empty or undefined, all results will be cached for DEFAULT_CACHE_DURATION.
-DEFAULT_CACHE_DURATION = int(os.environ.get('GRAPHITE_DEFAULT_CACHE_DURATION', '0'))
+DEFAULT_CACHE_DURATION = int(os.environ.get('GRAPHITE_DEFAULT_CACHE_DURATION', '60'))
 #DEFAULT_CACHE_POLICY = [(0, 60), # default is 60 seconds
 #                        (7200, 120), # >= 2 hour queries are cached 2 minutes
 #                        (21600, 180)] # >= 6 hour queries are cached 3 minutes
@@ -423,6 +423,17 @@ FUNCTION_PLUGINS = []
 #####################################
 # Additional Django Settings #
 #####################################
+
+LOG_DIR = '/var/log/graphite'
+_SECRET_KEY = '$(date +%s | sha256sum | base64 | head -c 64)'
+SECRET_KEY = os.environ.get('GRAPHITE_SECRET_KEY', _SECRET_KEY)
+
+if (os.getenv("MEMCACHE_HOST") is not None):
+    MEMCACHE_HOSTS = os.getenv("MEMCACHE_HOST").split(",")
+
+if (os.getenv("DEFAULT_CACHE_DURATION") is not None):
+    DEFAULT_CACHE_DURATION = int(os.getenv("CACHE_DURATION"))
+
 STATSD_HOST = os.environ.get('GRAPHITE_STATSD_HOST', '127.0.0.1')
 if STATSD_HOST != '':
     from graphite.app_settings import *

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -16,7 +16,7 @@ import os
 # In Django 1.5+ set this to the list of hosts your graphite instances is
 # accessible as. See:
 # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS
-ALLOWED_HOSTS = [ host.strip() for host in os.environ.get('GRAPHITE_ALLOWED_HOSTS', "*").split(",") ]
+ALLOWED_HOSTS = [host.strip() for host in os.environ.get('GRAPHITE_ALLOWED_HOSTS', "*").split(",")]
 
 # Set your local timezone (Django's default is America/Chicago)
 # If your graphs appear to be offset by a couple hours then this probably
@@ -44,7 +44,7 @@ LOG_FILE_CACHE = os.environ.get("GRAPHITE_LOG_FILE_CACHE", 'cache.log')
 LOG_FILE_RENDERING = os.environ.get("GRAPHITE_LOG_FILE_RENDERING", 'rendering.log')
 
 # Enable full debug page display on exceptions (Internal Server Error pages)
-DEBUG = os.environ.get("GRAPHITE_DEBUG", "false").lower() in ['1','true','yes']
+DEBUG = os.environ.get("GRAPHITE_DEBUG", "false").lower() in ['1', 'true', 'yes']
 
 # If using RRD files and rrdcached, set to the address or socket of the daemon
 #FLUSHRRDCACHED = 'unix:/var/run/rrdcached.sock'
@@ -278,7 +278,7 @@ CLUSTER_SERVERS = [x for x in [host.strip() for host in os.environ.get('GRAPHITE
 # Be careful when increasing the number of threads, in particular if your start
 # multiple graphite-web processes (with uwsgi or similar) as this will increase
 # memory consumption (and number of connections to memcached).
-USE_WORKER_POOL = os.environ.get("GRAPHITE_USE_WORKER_POOL", "true").lower() in ['1','true','yes']
+USE_WORKER_POOL = os.environ.get("GRAPHITE_USE_WORKER_POOL", "true").lower() in ['1', 'true', 'yes']
 
 # The number of worker threads that should be created per backend server.
 # It makes sense to have more than one thread per backend server if

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -2,36 +2,49 @@
 # Edit this file to customize the default Graphite webapp settings
 #
 # Additional customizations to Django settings can be added to this file as well
-
+import os
 #####################################
 # General Configuration #
 #####################################
+#
 # Set this to a long, random unique string to use as a secret key for this
 # install. This key is used for salting of hashes used in auth tokens,
 # CRSF middleware, cookie storage, etc. This should be set identically among
 # instances if used behind a load balancer.
-#SECRET_KEY = 'UNSAFE_DEFAULT'
+SECRET_KEY = os.environ.get('GRAPHITE_SECRET_KEY', "UNSAFE_DEFAULT")
 
 # In Django 1.5+ set this to the list of hosts your graphite instances is
 # accessible as. See:
 # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS
-#ALLOWED_HOSTS = [ '*' ]
+ALLOWED_HOSTS = [ host.strip() for host in os.environ.get('GRAPHITE_ALLOWED_HOSTS', "*").split(",") ]
 
 # Set your local timezone (Django's default is America/Chicago)
 # If your graphs appear to be offset by a couple hours then this probably
 # needs to be explicitly set to your local timezone.
-#TIME_ZONE = 'America/Los_Angeles'
+TIME_ZONE = os.environ.get('GRAPHITE_TIME_ZONE', 'Etc/UTC')
+
+# Set the default short date format. See strftime(3) for supported sequences.
+#DATE_FORMAT = '%m/%d'
 
 # Override this to provide documentation specific to your Graphite deployment
-#DOCUMENTATION_URL = "http://graphite.readthedocs.org/"
+#DOCUMENTATION_URL = "http://graphite.readthedocs.io/"
 
 # Logging
-#LOG_RENDERING_PERFORMANCE = True
-#LOG_CACHE_PERFORMANCE = True
-#LOG_METRIC_ACCESS = True
+# These can also be configured using Django's LOGGING:
+# https://docs.djangoproject.com/en/1.11/topics/logging/
+LOG_ROTATION = os.environ.get("GRAPHITE_LOG_ROTATION", "true").lower() in ['1', 'true', 'yes']
+LOG_ROTATION_COUNT = int(os.environ.get('GRAPHITE_LOG_ROTATION_COUNT', '1'))
+LOG_RENDERING_PERFORMANCE = os.environ.get("GRAPHITE_LOG_RENDERING_PERFORMANCE", "true").lower() in ['1', 'true', 'yes']
+LOG_CACHE_PERFORMANCE = os.environ.get("GRAPHITE_LOG_CACHE_PERFORMANCE", "true").lower() in ['1', 'true', 'yes']
+
+# Filenames for log output, set to '-' to log to stderr
+LOG_FILE_INFO = os.environ.get("GRAPHITE_LOG_FILE_INFO", 'info.log')
+LOG_FILE_EXCEPTION = os.environ.get("GRAPHITE_LOG_FILE_EXCEPTION", 'exception.log')
+LOG_FILE_CACHE = os.environ.get("GRAPHITE_LOG_FILE_CACHE", 'cache.log')
+LOG_FILE_RENDERING = os.environ.get("GRAPHITE_LOG_FILE_RENDERING", 'rendering.log')
 
 # Enable full debug page display on exceptions (Internal Server Error pages)
-#DEBUG = True
+DEBUG = os.environ.get("GRAPHITE_DEBUG", "false").lower() in ['1','true','yes']
 
 # If using RRD files and rrdcached, set to the address or socket of the daemon
 #FLUSHRRDCACHED = 'unix:/var/run/rrdcached.sock'
@@ -46,22 +59,57 @@
 # as every webapp in the cluster should use the exact same values to prevent
 # unneeded cache misses. Set to [] to disable caching of images and fetched data
 #MEMCACHE_HOSTS = ['10.10.10.10:11211', '10.10.10.11:11211', '10.10.10.12:11211']
-#DEFAULT_CACHE_DURATION = 60 # Cache images and data for 1 minute
 
+# Metric data and graphs are cached for one minute by default. If defined,
+# DEFAULT_CACHE_POLICY is a list of tuples of minimum query time ranges mapped
+# to the cache duration for the results. This allows for larger queries to be
+# cached for longer periods of times. All times are in seconds. If the policy is
+# empty or undefined, all results will be cached for DEFAULT_CACHE_DURATION.
+DEFAULT_CACHE_DURATION = int(os.environ.get('GRAPHITE_DEFAULT_CACHE_DURATION', '0'))
+#DEFAULT_CACHE_POLICY = [(0, 60), # default is 60 seconds
+#                        (7200, 120), # >= 2 hour queries are cached 2 minutes
+#                        (21600, 180)] # >= 6 hour queries are cached 3 minutes
+#MEMCACHE_KEY_PREFIX = 'graphite'
+
+# This lists the memcached options. Default is an empty dict.
+# Accepted options depend on the Memcached implementation and the Django version.
+# Until Django 1.10, options are used only for pylibmc.
+# Starting from 1.11, options are used for both python-memcached and pylibmc.
+#MEMCACHE_OPTIONS = { 'socket_timeout': 0.5 }
+
+# this setting controls the default xFilesFactor used for query-time aggregration
+DEFAULT_XFILES_FACTOR = 0
+
+# Set URL_PREFIX when deploying graphite-web to a non-root location
+#URL_PREFIX = '/graphite'
+
+# Graphite uses Django Tagging to support tags in Events. By default each
+# tag is limited to 50 characters in length.
+#MAX_TAG_LENGTH = 50
+
+# Interval for the Auto-Refresh feature in the Composer, measured in seconds.
+#AUTO_REFRESH_INTERVAL = 60
+
+# Timeouts for find and render requests
+#FIND_TIMEOUT = 3.0  # Timeout for metric find requests
+#FETCH_TIMEOUT = 3.0  # Timeout to fetch series data
 
 #####################################
 # Filesystem Paths #
 #####################################
+#
 # Change only GRAPHITE_ROOT if your install is merely shifted from /opt/graphite
 # to somewhere else
 #GRAPHITE_ROOT = '/opt/graphite'
 
-# Most installs done outside of a separate tree such as /opt/graphite will only
-# need to change these three settings. Note that the default settings for each
-# of these is relative to GRAPHITE_ROOT
+# Most installs done outside of a separate tree such as /opt/graphite will
+# need to change these settings. Note that the default settings for each
+# of these is relative to GRAPHITE_ROOT.
 #CONF_DIR = '/opt/graphite/conf'
 #STORAGE_DIR = '/opt/graphite/storage'
-#CONTENT_DIR = '/opt/graphite/webapp/content'
+#STATIC_ROOT = '/opt/graphite/static'
+#LOG_DIR = '/opt/graphite/storage/log/webapp'
+#INDEX_FILE = '/opt/graphite/storage/index'     # Search index file
 
 # To further or fully customize the paths, modify the following. Note that the
 # default settings for each of these are relative to CONF_DIR and STORAGE_DIR
@@ -71,52 +119,77 @@
 #GRAPHTEMPLATES_CONF = '/opt/graphite/conf/graphTemplates.conf'
 
 ## Data directories
-# NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
+#
+# NOTE: If any directory is unreadable in STANDARD_DIRS it will break metric browsing
+#
+#CERES_DIR = '/opt/graphite/storage/ceres'
 #WHISPER_DIR = '/opt/graphite/storage/whisper'
 #RRD_DIR = '/opt/graphite/storage/rrd'
-#DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
-#LOG_DIR = '/opt/graphite/storage/log/webapp'
-#INDEX_FILE = '/opt/graphite/storage/index'  # Search index file
+#
+# Data directories using the "Standard" metrics finder (i.e. not Ceres)
+#STANDARD_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
 
+## Data finders
+# It is possible to use an alternate storage layer than the default, Whisper,
+# in order to accommodate specific needs.
+# See: http://graphite.readthedocs.io/en/latest/storage-backends.html
+#
+# STORAGE_FINDERS = (
+#    'graphite.finders.remote.RemoteFinder',
+#    'graphite.finders.standard.StandardFinder',
+#    'graphite.finders.ceres.CeresFinder',
+# )
 
 #####################################
 # Email Configuration #
 #####################################
-# This is used for emailing rendered Graphs
-# Default backend is SMTP
+#
+# This is used for emailing rendered graphs. The default backend is SMTP.
 #EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+#
+# To drop emails on the floor, enable the Dummy backend instead.
+#EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+
 #EMAIL_HOST = 'localhost'
 #EMAIL_PORT = 25
 #EMAIL_HOST_USER = ''
 #EMAIL_HOST_PASSWORD = ''
 #EMAIL_USE_TLS = False
-# To drop emails on the floor, enable the Dummy backend:
-#EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 
 
 #####################################
 # Authentication Configuration #
 #####################################
+#
 ## LDAP / ActiveDirectory authentication setup
 #USE_LDAP_AUTH = True
 #LDAP_SERVER = "ldap.mycompany.com"
 #LDAP_PORT = 389
-#	OR
+#LDAP_USE_TLS = False
+
+## Manual URI / query setup
 #LDAP_URI = "ldaps://ldap.mycompany.com:636"
 #LDAP_SEARCH_BASE = "OU=users,DC=mycompany,DC=com"
 #LDAP_BASE_USER = "CN=some_readonly_account,DC=mycompany,DC=com"
 #LDAP_BASE_PASS = "readonly_account_password"
 #LDAP_USER_QUERY = "(username=%s)"  #For Active Directory use "(sAMAccountName=%s)"
-#
+
+# User DN template to use for binding (and authentication) against the
+# LDAP server. %(username) is replaced with the username supplied at
+# graphite login.
+#LDAP_USER_DN_TEMPLATE = "CN=%(username)s,OU=users,DC=mycompany,DC=com"
+
 # If you want to further customize the ldap connection options you should
 # directly use ldap.set_option to set the ldap module's global options.
 # For example:
 #
 #import ldap
-#ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
+#ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW) # Use ldap.OPT_X_TLS_DEMAND to force TLS
+#ldap.set_option(ldap.OPT_REFERRALS, 0) # Enable for Active Directory
 #ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, "/etc/ssl/ca")
 #ldap.set_option(ldap.OPT_X_TLS_CERTFILE, "/etc/ssl/mycert.pem")
 #ldap.set_option(ldap.OPT_X_TLS_KEYFILE, "/etc/ssl/mykey.pem")
+#ldap.set_option(ldap.OPT_DEBUG_LEVEL, 65535) # To enable verbose debugging
 # See http://www.python-ldap.org/ for further details on these options.
 
 ## REMOTE_USER authentication. See: https://docs.djangoproject.com/en/dev/howto/auth-remote-user/
@@ -126,19 +199,41 @@
 #LOGIN_URL = '/account/login'
 
 
+###############################
+# Authorization for Dashboard #
+###############################
+# By default, there is no security on dashboards - any user can add, change or delete them.
+# This section provides 3 different authorization models, of varying strictness.
+
+# If set to True, users must be logged in to save or delete dashboards. Defaults to False
+#DASHBOARD_REQUIRE_AUTHENTICATION = True
+
+# If set to the name of a user group, dashboards can be saved and deleted by any user in this
+# group.  Groups can be set in the Django Admin app, or in LDAP.  Defaults to None.
+# NOTE: Ignored if DASHBOARD_REQUIRE_AUTHENTICATION is not set
+#DASHBOARD_REQUIRE_EDIT_GROUP = 'dashboard-editors-group'
+
+# If set to True, dashboards can be saved or deleted by any user having the appropriate
+# (change or delete) permission (as set in the Django Admin app).  Defaults to False
+# NOTE: Ignored if DASHBOARD_REQUIRE_AUTHENTICATION is not set
+#DASHBOARD_REQUIRE_PERMISSIONS = True
+
+
 ##########################
 # Database Configuration #
 ##########################
+#
 # By default sqlite is used. If you cluster multiple webapps you will need
 # to setup an external database (such as MySQL) and configure all of the webapp
 # instances to use the same database. Note that this database is only used to store
 # Django models such as saved graphs, dashboards, user preferences, etc.
 # Metric data is not stored here.
 #
-# DO NOT FORGET TO RUN 'manage.py syncdb' AFTER SETTING UP A NEW DATABASE
+# DO NOT FORGET TO RUN MIGRATIONS AFTER SETTING UP A NEW DATABASE
+# http://graphite.readthedocs.io/en/latest/config-database-setup.html
+#
 #
 # The following built-in database engines are available:
-#  django.db.backends.postgresql          # Removed in Django 1.4
 #  django.db.backends.postgresql_psycopg2
 #  django.db.backends.mysql
 #  django.db.backends.sqlite3
@@ -163,19 +258,86 @@
 #########################
 # Cluster Configuration #
 #########################
-# (To avoid excessive DNS lookups you want to stick to using IP addresses only in this entire section)
 #
+# To avoid excessive DNS lookups you want to stick to using IP addresses only
+# in this entire section.
+#
+
 # This should list the IP address (and optionally port) of the webapp on each
 # remote server in the cluster. These servers must each have local access to
 # metric data. Note that the first server to return a match for a query will be
 # used.
 #CLUSTER_SERVERS = ["10.0.2.2:80", "10.0.2.3:80"]
+CLUSTER_SERVERS = [x for x in [host.strip() for host in os.environ.get('GRAPHITE_CLUSTER_SERVERS', '').split(",")] if x]
 
-## These are timeout values (in seconds) for requests to remote webapps
-#REMOTE_STORE_FETCH_TIMEOUT = 6   # Timeout to fetch series data
-#REMOTE_STORE_FIND_TIMEOUT = 2.5  # Timeout for metric find requests
-#REMOTE_STORE_RETRY_DELAY = 60    # Time before retrying a failed remote webapp
-#REMOTE_FIND_CACHE_DURATION = 300 # Time to cache remote metric find results
+# Creates a pool of worker threads to which tasks can be dispatched. This makes
+# sense if there are multiple CLUSTER_SERVERS because then the communication
+# with them can be parallelized
+# The number of threads is equal to:
+#   POOL_WORKERS_PER_BACKEND * len(CLUSTER_SERVERS) + POOL_WORKERS
+# Be careful when increasing the number of threads, in particular if your start
+# multiple graphite-web processes (with uwsgi or similar) as this will increase
+# memory consumption (and number of connections to memcached).
+USE_WORKER_POOL = os.environ.get("GRAPHITE_USE_WORKER_POOL", "true").lower() in ['1','true','yes']
+
+# The number of worker threads that should be created per backend server.
+# It makes sense to have more than one thread per backend server if
+# the graphite-web web server itself is multi threaded and can handle multiple
+# incoming requests at once.
+POOL_WORKERS_PER_BACKEND = int(os.environ.get('GRAPHITE_POOL_WORKERS_PER_BACKEND', '8'))
+
+# A baseline number of workers that should always be created, no matter how many
+# cluster servers are configured. These are used for other tasks that can be
+# off-loaded from the request handling threads.
+POOL_WORKERS = int(os.environ.get('GRAPHITE_POOL_WORKERS', '1'))
+
+# Maximum number of worker threads for concurrent storage operations
+#POOL_MAX_WORKERS = 10
+
+# This setting controls whether https is used to communicate between cluster members
+#INTRACLUSTER_HTTPS = False
+
+# These are timeout values (in seconds) for requests to remote webapps
+REMOTE_FIND_TIMEOUT = float(os.environ.get('GRAPHITE_REMOTE_FIND_TIMEOUT', '30'))    # Timeout for metric find requests
+REMOTE_FETCH_TIMEOUT = float(os.environ.get('GRAPHITE_REMOTE_FETCH_TIMEOUT', '60'))  # Timeout to fetch series data
+REMOTE_RETRY_DELAY = float(os.environ.get('GRAPHITE_REMOTE_RETRY_DELAY', '0'))       # Time before retrying a failed remote webapp
+
+# Fail all requests if any remote webapp call fails
+#STORE_FAIL_ON_ERROR = False
+
+# Try to detect when a cluster server is localhost and don't forward queries
+REMOTE_EXCLUDE_LOCAL = False
+
+# Number of retries for a specific remote data fetch.
+MAX_FETCH_RETRIES = int(os.environ.get('GRAPHITE_MAX_FETCH_RETRIES', '2'))
+
+FIND_CACHE_DURATION = int(os.environ.get('GRAPHITE_FIND_CACHE_DURATION', '1')) # Time to cache remote metric find results
+# If the query doesn't fall entirely within the FIND_TOLERANCE window
+# we disregard the window. This prevents unnecessary remote fetches
+# caused when carbon's cache skews node.intervals, giving the appearance
+# remote systems have data we don't have locally, which we probably do.
+#FIND_TOLERANCE = 2 * FIND_CACHE_DURATION
+
+#REMOTE_STORE_USE_POST = False    # Use POST instead of GET for remote requests
+
+# Size of the buffer used for streaming remote cluster responses. Set to 0 to avoid streaming deserialization.
+REMOTE_BUFFER_SIZE = int(os.environ.get('GRAPHITE_REMOTE_BUFFER_SIZE', '1048576'))
+
+# During a rebalance of a consistent hash cluster, after a partition event on a replication > 1 cluster,
+# or in other cases we might receive multiple TimeSeries data for a metric key.  Merge them together rather
+# that choosing the "most complete" one (pre-0.9.14 behaviour).
+#REMOTE_STORE_MERGE_RESULTS = True
+
+# Provide a list of HTTP headers that you want forwarded on from this host
+# when making a request to a remote webapp server in CLUSTER_SERVERS
+#REMOTE_STORE_FORWARD_HEADERS = [] # An iterable of HTTP header names
+
+## Prefetch cache
+# set to True to fetch all metrics using a single http request per remote server
+# instead of one http request per target, per remote server.
+# Especially useful when generating graphs with more than 4-5 targets or if
+# there's significant latency between this server and the backends.
+REMOTE_PREFETCH_DATA = os.environ.get("GRAPHITE_REMOTE_PREFETCH_DATA", "false").lower() in ['1', 'true', 'yes']
 
 ## Remote rendering settings
 # Set to True to enable rendering of Graphs on a remote webapp
@@ -186,30 +348,91 @@
 #RENDERING_HOSTS = []
 #REMOTE_RENDER_CONNECT_TIMEOUT = 1.0
 
-# If you are running multiple carbon-caches on this machine (typically behind a relay using
-# consistent hashing), you'll need to list the ip address, cache query port, and instance name of each carbon-cache
-# instance on the local machine (NOT every carbon-cache in the entire cluster). The default cache query port is 7002
-# and a common scheme is to use 7102 for instance b, 7202 for instance c, etc.
+# If you are running multiple carbon-caches on this machine (typically behind
+# a relay using consistent hashing), you'll need to list the ip address, cache
+# query port, and instance name of each carbon-cache instance on the local
+# machine (NOT every carbon-cache in the entire cluster). The default cache
+# query port is 7002 and a common scheme is to use 7102 for instance b, 7202
+# for instance c, etc.
+# If you're using consistent hashing, please keep an order of hosts the same as
+# order of DESTINATIONS in your relay - otherways you'll get cache misses.
 #
-# You *should* use 127.0.0.1 here in most cases
+# You *should* use 127.0.0.1 here in most cases.
+#
 #CARBONLINK_HOSTS = ["127.0.0.1:7002:a", "127.0.0.1:7102:b", "127.0.0.1:7202:c"]
-#CARBONLINK_TIMEOUT = 1.0
+CARBONLINK_HOSTS = [host.strip() for host in os.environ.get('GRAPHITE_CARBONLINK_HOSTS', "127.0.0.1:7002").split(",")]
+
+CARBONLINK_TIMEOUT = float(os.environ.get('GRAPHITE_CARBONLINK_TIMEOUT', '1'))
+#CARBONLINK_RETRY_DELAY = 15 # Seconds to blacklist a failed remote server
+#
+
+# Type of metric hashing function.
+# The default `carbon_ch` is Graphite's traditional consistent-hashing implementation.
+# Alternatively, you can use `fnv1a_ch`, which supports the Fowler-Noll-Vo hash
+# function (FNV-1a) hash implementation offered by the carbon-c-relay project
+# https://github.com/grobian/carbon-c-relay
+#
+# Supported values: carbon_ch, fnv1a_ch
+#
+CARBONLINK_HASHING_TYPE = os.environ.get("GRAPHITE_CARBONLINK_HASHING_TYPE", 'carbon_ch')
+
+# A "keyfunc" is a user-defined python function that is given a metric name
+# and returns a string that should be used when hashing the metric name.
+# This is important when your hashing has to respect certain metric groupings.
+#CARBONLINK_HASHING_KEYFUNC = "/opt/graphite/bin/keyfuncs.py:my_keyfunc"
+
+# Prefix for internal carbon statistics.
+#CARBON_METRIC_PREFIX='carbon'
+
+# The replication factor to use with consistent hashing.
+# This should usually match the value configured in Carbon.
+REPLICATION_FACTOR = int(os.environ.get('GRAPHITE_REPLICATION_FACTOR', '1'))
+
+#####################################
+# TagDB Settings #
+#####################################
+# Tag Database
+#TAGDB = 'graphite.tags.localdatabase.LocalDatabaseTagDB'
+TAGDB = os.environ.get('GRAPHITE_TAGDB', '')
+
+# Time to cache seriesByTag results
+TAGDB_CACHE_DURATION = int(os.environ.get('GRAPHITE_TAGDB_CACHE_DURATION') or 60)
+
+# Autocomplete default result limit
+TAGDB_AUTOCOMPLETE_LIMIT = int(os.environ.get('GRAPHITE_TAGDB_AUTOCOMPLETE_LIMIT') or 100)
+
+# Settings for Redis TagDB
+#TAGDB_REDIS_HOST = 'localhost'
+#TAGDB_REDIS_PORT = 6379
+#TAGDB_REDIS_DB = 0
+
+# Settings for HTTP TagDB
+TAGDB_HTTP_URL = os.environ.get('GRAPHITE_TAGDB_HTTP_URL', '')
+TAGDB_HTTP_USER = os.environ.get('GRAPHITE_TAGDB_HTTP_USER', '')
+TAGDB_HTTP_PASSWORD = os.environ.get('GRAPHITE_TAGDB_HTTP_PASSWORD', '')
+# Does the remote TagDB support autocomplete?
+TAGDB_HTTP_AUTOCOMPLETE = os.environ.get('GRAPHITE_TAGDB_HTTP_AUTOCOMPLETE', 'false').lower() in ['1', 'true', 'yes']
+
+#####################################
+# Function plugins #
+#####################################
+# List of custom function plugin modules
+# See: http://graphite.readthedocs.io/en/latest/functions.html#function-plugins
+FUNCTION_PLUGINS = []
 
 #####################################
 # Additional Django Settings #
 #####################################
-# Uncomment the following line for direct access to Django settings such as
-# MIDDLEWARE_CLASSES or APPS
-#from graphite.app_settings import *
-
-import os
-
-LOG_DIR = '/var/log/graphite'
-SECRET_KEY = '$(date +%s | sha256sum | base64 | head -c 64)'
-
-if (os.getenv("MEMCACHE_HOST") is not None):
-    MEMCACHE_HOSTS = os.getenv("MEMCACHE_HOST").split(",")
-
-if (os.getenv("DEFAULT_CACHE_DURATION") is not None):
-    DEFAULT_CACHE_DURATION = int(os.getenv("CACHE_DURATION"))
-
+STATSD_HOST = os.environ.get('GRAPHITE_STATSD_HOST', '127.0.0.1')
+if STATSD_HOST != '':
+    from graphite.app_settings import *
+    MIDDLEWARE = (
+        'django_statsd.middleware.GraphiteRequestTimingMiddleware',
+        'django_statsd.middleware.GraphiteMiddleware',
+        ) + MIDDLEWARE
+    try:
+        MIDDLEWARE_CLASSES
+    except NameError:
+        pass
+    else:
+        MIDDLEWARE_CLASSES = MIDDLEWARE


### PR DESCRIPTION
- Backporting environment variables from [graphite-mt](https://github.com/raintank/graphite-mt)
- Adding more variables (e.g. for carbon)
- making it works with local storage
- fixing virtualenv bug
- backporting django statsd from graphite-mt too
- actualizing carbon.conf