### PR TITLE
Introducing Redis TagDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ DOCKER ASSIGNED   | /etc/nginx                 | nginx config
 DOCKER ASSIGNED   | /opt/statsd                | statsd config
 DOCKER ASSIGNED   | /etc/logrotate.d           | logrotate config
 DOCKER ASSIGNED   | /var/log                   | log files
+DOCKER ASSIGNED   | /var/lib/redis             | Redis TagDB data (optional)
 
 ### Base Image
 
@@ -143,6 +144,21 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_MAX_FETCH_RETRIES: (2) Number of retries for a specific remote data fetch
 * GRAPHITE_FIND_CACHE_DURATION: (0) Time to cache remote metric find results
 * GRAPHITE_STATSD_HOST: ("127.0.0.1") If set, django_statsd.middleware.GraphiteRequestTimingMiddleware and django_statsd.middleware.GraphiteMiddleware will be enabled.
+
+## TagDB
+Graphite stores tag information in a separate tag database (TagDB). Please check [tags documentation](https://graphite.readthedocs.io/en/latest/tags.html) for details.
+
+* GRAPHITE_TAGDB: ('graphite.tags.localdatabase.LocalDatabaseTagDB') TagDB is a pluggable store, by default it uses the local SQLite database.
+* REDIS_TAGDB: (false) if set to true will use local Redis instance to store tags. 
+* GRAPHITE_TAGDB_CACHE_DURATION: (60) Time to cache seriesByTag results.
+* GRAPHITE_TAGDB_AUTOCOMPLETE_LIMIT: (100) Autocomplete default result limit.
+* GRAPHITE_TAGDB_REDIS_HOST: ('localhost') Redis TagDB host
+* GRAPHITE_TAGDB_REDIS_PORT: (6379) Redis TagDB port
+* GRAPHITE_TAGDB_REDIS_DB: (0) Redis TagDB database number
+* GRAPHITE_TAGDB_HTTP_URL: ('') URL for HTTP TagDB
+* GRAPHITE_TAGDB_HTTP_USER: ('') Username for HTTP TagDB
+* GRAPHITE_TAGDB_HTTP_PASSWORD: ('') Password for HTTP TagDB
+* GRAPHITE_TAGDB_HTTP_AUTOCOMPLETE: (false) Does the remote TagDB support autocomplete?
 
 ## Change the Configuration
 

--- a/conf/etc/redis/redis.conf
+++ b/conf/etc/redis/redis.conf
@@ -1,0 +1,44 @@
+daemonize no
+pidfile /var/run/redis/redis-server.pid
+port 6379
+bind 127.0.0.1
+timeout 0
+tcp-keepalive 0
+loglevel notice
+logfile /var/log/redis/redis-server.log
+databases 16
+save 900 1
+save 300 10
+save 60 10000
+stop-writes-on-bgsave-error yes
+rdbcompression yes
+rdbchecksum yes
+dbfilename dump.rdb
+dir /var/lib/redis
+slave-serve-stale-data yes
+slave-read-only yes
+repl-disable-tcp-nodelay no
+slave-priority 100
+appendonly yes
+appendfilename "appendonly.aof"
+appendfsync everysec
+no-appendfsync-on-rewrite no
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+lua-time-limit 5000
+slowlog-log-slower-than 10000
+slowlog-max-len 128
+notify-keyspace-events ""
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
+list-max-ziplist-entries 512
+list-max-ziplist-value 64
+set-max-intset-entries 512
+zset-max-ziplist-entries 128
+zset-max-ziplist-value 64
+activerehashing yes
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit slave 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+hz 10
+aof-rewrite-incremental-fsync yes

--- a/conf/etc/service/redis/run
+++ b/conf/etc/service/redis/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+[[ -n ${REDIS_TAGDB} ]] || exit 1
+exec /usr/bin/redis-server /etc/redis/redis.conf

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -392,8 +392,13 @@ REPLICATION_FACTOR = int(os.environ.get('GRAPHITE_REPLICATION_FACTOR', '1'))
 # TagDB Settings #
 #####################################
 # Tag Database
-#TAGDB = 'graphite.tags.localdatabase.LocalDatabaseTagDB'
-TAGDB = os.environ.get('GRAPHITE_TAGDB', '')
+
+# set TAGDB to Redis if REDIS_TAGDB env var is set
+_REDIS_TAGDB = os.environ.get('REDIS_TAGDB', 'false').lower() in ['1', 'true', 'yes']
+
+# default TAGDB is local database. Set to '' to disable
+TAGDB = 'graphite.tags.redis.RedisTagDB' if _REDIS_TAGDB else \
+    os.environ.get('GRAPHITE_TAGDB', 'graphite.tags.localdatabase.LocalDatabaseTagDB')
 
 # Time to cache seriesByTag results
 TAGDB_CACHE_DURATION = int(os.environ.get('GRAPHITE_TAGDB_CACHE_DURATION') or 60)
@@ -402,9 +407,9 @@ TAGDB_CACHE_DURATION = int(os.environ.get('GRAPHITE_TAGDB_CACHE_DURATION') or 60
 TAGDB_AUTOCOMPLETE_LIMIT = int(os.environ.get('GRAPHITE_TAGDB_AUTOCOMPLETE_LIMIT') or 100)
 
 # Settings for Redis TagDB
-#TAGDB_REDIS_HOST = 'localhost'
-#TAGDB_REDIS_PORT = 6379
-#TAGDB_REDIS_DB = 0
+TAGDB_REDIS_HOST = os.environ.get('GRAPHITE_TAGDB_REDIS_HOST', 'localhost')
+TAGDB_REDIS_PORT = int(os.environ.get('GRAPHITE_TAGDB_REDIS_PORT') or 6379)
+TAGDB_REDIS_DB = int(os.environ.get('GRAPHITE_TAGDB_REDIS_DB') or 0)
 
 # Settings for HTTP TagDB
 TAGDB_HTTP_URL = os.environ.get('GRAPHITE_TAGDB_HTTP_URL', '')


### PR DESCRIPTION
- fixing TagDB regression introduced in 1.1.4-4 (issue #59)
- introducing optional local Redis TagDB (use REDIS_TAGDB=1 env. var.)