### PR TITLE
Build and mount in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: "2"
 
 services:
   statsd:
-   image: graphiteapp/graphite-statsd
+   build:
+    context: .
+   volumes:
+    - ./conf/opt/graphite/conf:/opt/graphite/conf
    ports:
     - "80:80"
     - "2003-2004:2003-2004"


### PR DESCRIPTION
Docker compose will now build directly from Dockerfile instead of downloading image. Mount conf directory for easier configuration change.