### PR TITLE
using environment variable for URL_PREFIX in graphite-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_MAX_FETCH_RETRIES: (2) Number of retries for a specific remote data fetch
 * GRAPHITE_FIND_CACHE_DURATION: (0) Time to cache remote metric find results
 * GRAPHITE_STATSD_HOST: ("127.0.0.1") If set, django_statsd.middleware.GraphiteRequestTimingMiddleware and django_statsd.middleware.GraphiteMiddleware will be enabled.
+* GRAPHITE_URL_ROOT: ('') Sets a url prefix if deploying graphite-web to a non-root location.
 
 ## TagDB
 Graphite stores tag information in a separate tag database (TagDB). Please check [tags documentation](https://graphite.readthedocs.io/en/latest/tags.html) for details.

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -81,7 +81,7 @@ DEFAULT_CACHE_DURATION = int(os.environ.get('GRAPHITE_DEFAULT_CACHE_DURATION', '
 DEFAULT_XFILES_FACTOR = 0
 
 # Set URL_PREFIX when deploying graphite-web to a non-root location
-#URL_PREFIX = '/graphite'
+URL_PREFIX = str(os.environ.get('GRAPHITE_URL_ROOT', ''))
 
 # Graphite uses Django Tagging to support tags in Events. By default each
 # tag is limited to 50 characters in length.


### PR DESCRIPTION
Don't know if there was any reason for this parameter to be commented in the settings file initially. 

Thought it could be useful like this for people deploying graphite-web to a non root url location. 

This change doesn't modify in any way the normal behaviour. It just allows someone to have a URL_PREFIX set with the 'GRAPHITE_URL_ROOT' environment variable.

First contribution -> give me feedback , especially if this is really bad :-) 