### PR TITLE
Add features to the entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ Use `RELAY=1` environment variable to enable carbon relay instance. Use `[relay]
 ## Logrotate
 By default logs are rotated daily, using built-in `/etc/periodic/daily/logrotate` script. Please note, that according to Docker [logging best practices](https://success.docker.com/article/logging-best-practices) "Ideally, applications log to stdout/stderr, and Docker sends those logs to the configured logging destination.". You can use `-` as log file name for such behaviour.
 
+## Runit
+Each service started and controlled by runit will be gracefully shutdown when stopping the container : wait up to 7 seconds for the service to become down, then it will be killed. The runit environment variable `$SVWAIT` overrides this default timeout. Additionnally, a global timeout can be also specified with the docker-run option `--stop-timeout`.
+Each service started by default can be disabled by setting an environment variable named as : `$<service name>_DISABLED`. For instance : `CARBON_AGGREGATOR_DISABLED=1`, `STATSD_DISABLED=1`...
+
+## Startup custom scripts
+At startup, entrypoint will run all scripts found in the directory /etc/run_once. It can be mounted with a docker-run option like this : `--mount type=bind,source=/path/to/run_once,destination=/etc/run_once`.
+
 ## Change the Configuration
 
 Read up on Graphite's [post-install tasks](https://graphite.readthedocs.org/en/latest/install.html#post-install-tasks).

--- a/conf/entrypoint
+++ b/conf/entrypoint
@@ -1,9 +1,56 @@
 #!/bin/sh
 
+## Inspired from the script found at
+##   https://sanjeevan.co.uk/blog/running-services-inside-a-container-using-runit-and-alpine-linux/
+
+shutdown() {
+  echo "shutting down container"
+
+  # first shutdown any service started by runit
+  for _srv in $(ls -1 /etc/service); do
+    sv force-stop $_srv
+  done
+
+  # shutdown runsvdir command
+  kill -HUP $RUNSVDIR
+  wait $RUNSVDIR
+
+  # give processes time to stop
+  sleep 0.5
+
+  # kill any other processes still running in the container
+  for _pid  in $(ps -eo pid | grep -v PID  | tr -d ' ' | grep -v '^1$' | head -n -6); do
+    timeout -t 5 /bin/sh -c "kill $_pid && wait $_pid || kill -9 $_pid"
+  done
+  exit
+}
+
 . /opt/graphite/bin/activate
 
-# Ensure /usr/local/bin is in PATH. On some
-# weird platforms,this might not be the case
 PATH="${PATH}:/usr/local/bin"
 
-runsvdir -P /etc/service
+# run all scripts in the run_once folder
+[ -d /etc/run_once ] && /bin/run-parts /etc/run_once
+
+## check services to disable
+for _srv in $(ls -1 /etc/service); do
+    eval X=$`echo -n $_srv | tr [:lower:]- [:upper:]_`_DISABLED
+    [ -n "$X" ] && touch /etc/service/$_srv/down
+done
+
+exec runsvdir -P /etc/service &
+
+RUNSVDIR=$!
+echo "Started runsvdir, PID is $RUNSVDIR"
+echo "wait for processes to start...."
+
+sleep 5
+for _srv in $(ls -1 /etc/service); do
+    sv status $_srv
+done
+
+# catch shutdown signals
+trap shutdown SIGTERM SIGHUP SIGQUIT SIGINT
+wait $RUNSVDIR
+
+shutdown

--- a/conf/etc/service/carbon-aggregator/run
+++ b/conf/etc/service/carbon-aggregator/run
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-rm -f /opt/graphite/storage/carbon-aggregator-a.pid
 exec python3 /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1

--- a/conf/etc/service/carbon-relay/run
+++ b/conf/etc/service/carbon-relay/run
@@ -2,5 +2,4 @@
 
 [[ -n "${RELAY}" ]] || exit 1
 
-rm -f /opt/graphite/storage/carbon-relay-a.pid
 exec python3 /opt/graphite/bin/carbon-relay.py start --debug 2>&1

--- a/conf/etc/service/carbon/run
+++ b/conf/etc/service/carbon/run
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-rm -f /opt/graphite/storage/carbon-cache-a.pid
 exec python3 /opt/graphite/bin/carbon-cache.py start --debug 2>&1


### PR DESCRIPTION
* Gracefully stop all services started by runit at shutdown.
  SVWAIT variable and the docker option  --stop-timeout can be used to avoid loosing metrics when carbon-cache has a huge cache full.
* Allow custom scripts to run at startup by using the docker mount option, ie :
  `--mount type=bind,source=/on_host/run_once,destination=/etc/run_once`
* runit services can be really disabled by using environment variable like this :
` <service name>_DISABLED`
  ie: `COLLECTD_DISABLED=1, CARBON_AGGREGATOR_DISABLED=1` ...