### PR TITLE
Limit depth of find

### DIFF
--- a/conf/entrypoint
+++ b/conf/entrypoint
@@ -39,7 +39,7 @@ for _srv in $(ls -1 /etc/service); do
 done
 
 # remove stale pids
-find /opt/graphite/storage -name '*.pid' -delete
+find /opt/graphite/storage -maxdepth 1 -name '*.pid' -delete
 
 exec runsvdir -P /etc/service &
 


### PR DESCRIPTION
Without this limit in place, this searches all of the whisper directories on startup. In a large-ish installation this can take quite a long time, and it should never find pid files in there.