### PR TITLE
Automate carbon-cache instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Graphite stores tag information in a separate tag database (TagDB). Please check
 ## Collectd
 Use `COLLECTD=1` environment variable to enable local collectd instance
 
+## Carbon-cache
+If custom environment `GRAPHITE_CARBONLINK_HOSTS` variable is setup `carbon-cache` instances as daemons/services are [managed](./conf/etc/run_once/carbon-cache) based on the that, otherwise default instance (`127.0.0.1:7002`) is used.
+
+**Note**: if default port `7002` is used among the hosts, need to setup `CARBON_DISABLED=1` in the environment.
+
 ## Carbon-relay
 Use `RELAY=1` environment variable to enable carbon relay instance. Use `[relay]` section of carbon.conf to configure it.
 

--- a/conf/etc/run_once/carbon-cache
+++ b/conf/etc/run_once/carbon-cache
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "$GRAPHITE_CARBONLINK_HOSTS" ]; then
+    exit 0
+fi
+
+IFS=","
+for i in $GRAPHITE_CARBONLINK_HOSTS; do
+    INSTANCE_ID=$(echo $i | tr -d '[:space:]' | awk -F ':' '{print $3}')
+
+    [ -z $INSTANCE_ID ] && continue
+    S=/etc/service/carbon-$INSTANCE_ID
+    [ -d $S ] && continue
+    mkdir -p $S/log
+    sed "s/start/--instance=$INSTANCE_ID start/" /etc/service/carbon/run > $S/run
+    sed "s/carbon.log/carbon-$INSTANCE_ID.log/" /etc/service/carbon/log/run > $S/log/run
+    chmod +x $S/run $S/log/run
+done


### PR DESCRIPTION
Inspired  by @hamelg [suggestion](https://github.com/graphite-project/docker-graphite-statsd/issues/86#issuecomment-479902872).

If environment `GRAPHITE_CARBONLINK_HOSTS` variable is setup `carbon-cache` instances are managed based on the that, otherwise nothing is changed.

**Note**: if default port 7002 is used among the hosts, need to setup `CARBON_DISABLED=1` in the environment.