### PR TITLE
Disabling carbon tags w/env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ Additional environment variables can be set to adjust performance.
 ## TagDB
 Graphite stores tag information in a separate tag database (TagDB). Please check [tags documentation](https://graphite.readthedocs.io/en/latest/tags.html) for details.
 
+* CARBON_DISABLE_TAGS: (false) if set to 1 or true will disable TagDB on carbon-cache.
 * GRAPHITE_TAGDB: ('graphite.tags.localdatabase.LocalDatabaseTagDB') TagDB is a pluggable store, by default it uses the local SQLite database.
-* REDIS_TAGDB: (false) if set to true will use local Redis instance to store tags.
+* REDIS_TAGDB: (false) if set to 1 or true will use local Redis instance to store tags.
 * GRAPHITE_TAGDB_CACHE_DURATION: (60) Time to cache seriesByTag results.
 * GRAPHITE_TAGDB_AUTOCOMPLETE_LIMIT: (100) Autocomplete default result limit.
 * GRAPHITE_TAGDB_REDIS_HOST: ('localhost') Redis TagDB host

--- a/conf/etc/service/carbon/run
+++ b/conf/etc/service/carbon/run
@@ -3,4 +3,9 @@
 # disable if go-carbon enabled
 [[ -n "${GOCARBON}" ]] && exit 1
 
+if [ -n "${CARBON_DISABLE_TAGS}" ]; then
+    # trying to disable tags in carbon.conf file
+    sed -i 's/ENABLE_TAGS = True/ENABLE_TAGS = False/g' /opt/graphite/conf/carbon.conf
+fi
+
 exec python3 /opt/graphite/bin/carbon-cache.py start --debug 2>&1

--- a/conf/opt/graphite/conf/carbon.conf
+++ b/conf/opt/graphite/conf/carbon.conf
@@ -307,7 +307,7 @@ CARBON_METRIC_INTERVAL = 10
 GRAPHITE_URL = http://127.0.0.1:8080
 
 # Tag support, when enabled carbon will make HTTP calls to graphite-web to update the tag index
-# ENABLE_TAGS = True
+ENABLE_TAGS = True
 
 # Tag update interval, this specifies how frequently updates to existing series will trigger
 # an update to the tag index, the default setting is once every 100 updates


### PR DESCRIPTION
CARBON_DISABLE_TAGS sets `ENABLE_TAGS = False` if enabled.
Obviously it works only with default config with uncommented `ENABLE_TAGS = True`
Fixing #132 