### PR TITLE
conf/entrypoint: fix service disabling

### DIFF
--- a/conf/entrypoint
+++ b/conf/entrypoint
@@ -38,7 +38,7 @@ PATH="${PATH}:/usr/local/bin"
 ## check services to disable
 for _srv in $(ls -1 /etc/service); do
     eval X=$`echo -n $_srv | tr [:lower:]- [:upper:]_`_DISABLED
-    [ -n "$X" ] && touch /etc/service/$_srv/down
+    [ -n "$X" ] && rm -rf /etc/service/$_srv
 done
 
 # remove stale pids


### PR DESCRIPTION
the "down" file does not instruct runit to not start or stop the service, simply that it should be
"normally down". 

for example with `NGINX_DISABLED`:

```
sv status nginx
run: nginx: (pid 125) 364s, normally down
```

```
/ # ps aux|grep nginx
   52 root      0:00 runsv nginx
  125 root      0:00 nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf
  127 nginx     0:00 nginx: worker process
  128 nginx     0:00 nginx: worker process
  129 nginx     0:00 nginx: worker process
  130 nginx     0:00 nginx: worker process
```