### PR TITLE
Use alpine-pypy as base image, and use pypy instead of python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM alpine:3.12.0 as base
+FROM jamiehewland/alpine-pypy:3.6-7-alpine3.11 as base
 LABEL maintainer="Denys Zhdanov <denis.zhdanov@gmail.com>"
 
 RUN true \
  && apk add --no-cache \
       cairo \
+      cairo-dev \
       collectd \
       collectd-disk \
       collectd-nginx \
@@ -42,18 +43,14 @@ RUN true \
       git \
       libffi-dev \
       pkgconfig \
-      py3-cairo \
       openldap-dev \
-      python3-dev \
       rrdtool-dev \
       wget \
-      go==1.13.11-r0 \
+      go==1.13.13-r0 \
       jansson-dev \
       librdkafka-dev \
- && curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
- && python3 /tmp/get-pip.py && rm /tmp/get-pip.py \
- && pip install virtualenv==16.7.10 \
- && virtualenv /opt/graphite \
+      py3-virtualenv \
+ && virtualenv -p pypy3 /opt/graphite \
  && . /opt/graphite/bin/activate \
  && pip install \
       django==2.2.13 \
@@ -68,7 +65,8 @@ RUN true \
       python-ldap \
       mysqlclient \
       psycopg2 \
-      django-cockroachdb==2.2.*
+      django-cockroachdb==2.2.* \
+      cairocffi==1.1.0
 
 ARG version=1.1.7
 
@@ -78,7 +76,7 @@ ARG whisper_repo=https://github.com/graphite-project/whisper.git
 RUN git clone -b ${whisper_version} --depth 1 ${whisper_repo} /usr/local/src/whisper \
  && cd /usr/local/src/whisper \
  && . /opt/graphite/bin/activate \
- && python3 ./setup.py install
+ && pypy3 ./setup.py install
 
 # install carbon
 ARG carbon_version=${version}
@@ -87,7 +85,7 @@ RUN . /opt/graphite/bin/activate \
  && git clone -b ${carbon_version} --depth 1 ${carbon_repo} /usr/local/src/carbon \
  && cd /usr/local/src/carbon \
  && pip3 install -r requirements.txt \
- && python3 ./setup.py install
+ && pypy3 ./setup.py install
 
 # install graphite
 ARG graphite_version=${version}
@@ -96,7 +94,7 @@ RUN . /opt/graphite/bin/activate \
  && git clone -b ${graphite_version} --depth 1 ${graphite_repo} /usr/local/src/graphite-web \
  && cd /usr/local/src/graphite-web \
  && pip3 install -r requirements.txt \
- && python3 ./setup.py install
+ && pypy3 ./setup.py install
 
 # install statsd
 ARG statsd_version=0.8.6

--- a/conf/etc/service/carbon-aggregator/run
+++ b/conf/etc/service/carbon-aggregator/run
@@ -2,4 +2,4 @@
 
 [[ -f "./down" ]] && exit 1
 
-exec python3 /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1
+exec pypy3 /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1

--- a/conf/etc/service/carbon-relay/run
+++ b/conf/etc/service/carbon-relay/run
@@ -4,4 +4,4 @@
 
 [[ -f "./down" ]] && exit 1
 
-exec python3 /opt/graphite/bin/carbon-relay.py start --debug 2>&1
+exec pypy3 /opt/graphite/bin/carbon-relay.py start --debug 2>&1

--- a/conf/etc/service/carbon/run
+++ b/conf/etc/service/carbon/run
@@ -10,4 +10,4 @@ if [ -n "${CARBON_DISABLE_TAGS}" ]; then
     sed -i 's/ENABLE_TAGS = True/ENABLE_TAGS = False/g' /opt/graphite/conf/carbon.conf
 fi
 
-exec python3 /opt/graphite/bin/carbon-cache.py start --debug 2>&1
+exec pypy3 /opt/graphite/bin/carbon-cache.py start --debug 2>&1

--- a/conf/opt/graphite/bin/django_admin_init.sh
+++ b/conf/opt/graphite/bin/django_admin_init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cat <<EOF | python3 /opt/graphite/bin/django-admin.py shell
+cat <<EOF | pypy3 /opt/graphite/bin/django-admin.py shell
 from django.contrib.auth import get_user_model
 
 User = get_user_model()  # get the currently active user model


### PR DESCRIPTION
This brings improved performances for both carbon and graphite-web.
We're using cairocffi instead of pycairo for pypy compatibility.
We're switching to package virtualenv to get an error when interpreter
option is invalid.