### PR TITLE
Adding pypy build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github
+.idea
+.hadolint*
+.gitignore
+build*
+__build*

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,11 @@ RUN true \
       sqlite \
       expect \
       dcron \
-      mysql-client \
       python3-dev \
+      mysql-client \
+      mysql-dev \
       postgresql-client \
+      postgresql-dev \
       librdkafka \
       jansson \
  && rm -rf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM alpine:3.12.0 as base
+ARG BASEIMAGE=alpine:3.12.0
+FROM $BASEIMAGE as base
 LABEL maintainer="Denys Zhdanov <denis.zhdanov@gmail.com>"
 
 RUN true \
- && apk add --no-cache \
+ && apk add --update --no-cache \
       cairo \
+      cairo-dev \
       collectd \
       collectd-disk \
       collectd-nginx \
@@ -14,16 +16,13 @@ RUN true \
       nginx \
       nodejs \
       npm \
-      py3-pyldap \
       redis \
       runit \
       sqlite \
       expect \
       dcron \
-      py3-mysqlclient \
-      mysql-dev \
       mysql-client \
-      postgresql-dev \
+      python3-dev \
       postgresql-client \
       librdkafka \
       jansson \
@@ -36,26 +35,31 @@ RUN true \
 FROM base as build
 LABEL maintainer="Denys Zhdanov <denis.zhdanov@gmail.com>"
 
+ARG python_binary
+
 RUN true \
  && apk add --update \
       alpine-sdk \
       git \
-      libffi-dev \
       pkgconfig \
-      py3-cairo \
+      wget \
+      go \
+      cairo-dev \
+      libffi-dev \
       openldap-dev \
       python3-dev \
       rrdtool-dev \
-      wget \
-      go==1.13.11-r0 \
       jansson-dev \
       librdkafka-dev \
+      mysql-dev \
+      postgresql-dev \
  && curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
- && python3 /tmp/get-pip.py && rm /tmp/get-pip.py \
+ && $python_binary /tmp/get-pip.py && rm /tmp/get-pip.py \
  && pip install virtualenv==16.7.10 \
- && virtualenv /opt/graphite \
+ && virtualenv -p $python_binary /opt/graphite \
  && . /opt/graphite/bin/activate \
  && pip install \
+      cairocffi==1.1.0 \
       django==2.2.13 \
       django-statsd-mozilla \
       fadvise \
@@ -78,7 +82,7 @@ ARG whisper_repo=https://github.com/graphite-project/whisper.git
 RUN git clone -b ${whisper_version} --depth 1 ${whisper_repo} /usr/local/src/whisper \
  && cd /usr/local/src/whisper \
  && . /opt/graphite/bin/activate \
- && python3 ./setup.py install
+ && $python_binary ./setup.py install
 
 # install carbon
 ARG carbon_version=${version}
@@ -87,7 +91,7 @@ RUN . /opt/graphite/bin/activate \
  && git clone -b ${carbon_version} --depth 1 ${carbon_repo} /usr/local/src/carbon \
  && cd /usr/local/src/carbon \
  && pip3 install -r requirements.txt \
- && python3 ./setup.py install
+ && $python_binary ./setup.py install
 
 # install graphite
 ARG graphite_version=${version}
@@ -96,7 +100,7 @@ RUN . /opt/graphite/bin/activate \
  && git clone -b ${graphite_version} --depth 1 ${graphite_repo} /usr/local/src/graphite-web \
  && cd /usr/local/src/graphite-web \
  && pip3 install -r requirements.txt \
- && python3 ./setup.py install
+ && $python_binary ./setup.py install
 
 # install statsd
 ARG statsd_version=0.8.6

--- a/__build.sh
+++ b/__build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+VERSION=master
+docker buildx build . \
+        --build-arg python_binary=python3 \
+        --platform linux/arm,linux/arm64,linux/amd64 \
+        --no-cache \
+        --tag graphite-statsd:$VERSION

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+VERSION=master
+docker build . --build-arg python_binary=python3 --no-cache --tag graphite-statsd:$VERSION

--- a/build_pypy.sh
+++ b/build_pypy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+VERSION=master
+IMAGE=jamiehewland/alpine-pypy:3.6-7.3-alpine3.11
+docker build . \
+    --build-arg BASEIMAGE=${IMAGE} --build-arg python_binary=/usr/local/bin/pypy3 \
+    --no-cache --tag graphite-statsd:$VERSION-pypy

--- a/conf/etc/service/carbon-aggregator/run
+++ b/conf/etc/service/carbon-aggregator/run
@@ -2,4 +2,6 @@
 
 [[ -f "./down" ]] && exit 1
 
-exec python3 /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1
+BIN=python3
+[[ -f "/opt/graphite/bin/pypy" ]] && BIN=pypy
+exec ${BIN} /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1

--- a/conf/etc/service/carbon-aggregator/run
+++ b/conf/etc/service/carbon-aggregator/run
@@ -3,5 +3,5 @@
 [[ -f "./down" ]] && exit 1
 
 BIN=python3
-[[ -f "/opt/graphite/bin/pypy" ]] && BIN=pypy
+[[ -f "/opt/graphite/bin/pypy3" ]] && BIN=pypy
 exec ${BIN} /opt/graphite/bin/carbon-aggregator.py start --debug 2>&1

--- a/conf/etc/service/carbon-relay/run
+++ b/conf/etc/service/carbon-relay/run
@@ -4,4 +4,6 @@
 
 [[ -f "./down" ]] && exit 1
 
-exec python3 /opt/graphite/bin/carbon-relay.py start --debug 2>&1
+BIN=/opt/graphite/bin/python3
+[[ -f "/opt/graphite/bin/pypy3" ]] && BIN=/opt/graphite/bin/pypy3
+exec ${BIN} /opt/graphite/bin/carbon-relay.py start --debug 2>&1

--- a/conf/etc/service/carbon/run
+++ b/conf/etc/service/carbon/run
@@ -10,4 +10,6 @@ if [ -n "${CARBON_DISABLE_TAGS}" ]; then
     sed -i 's/ENABLE_TAGS = True/ENABLE_TAGS = False/g' /opt/graphite/conf/carbon.conf
 fi
 
-exec python3 /opt/graphite/bin/carbon-cache.py start --debug 2>&1
+BIN=/opt/graphite/bin/python3
+[[ -f "/opt/graphite/bin/pypy3" ]] && BIN=/opt/graphite/bin/pypy3
+exec ${BIN} /opt/graphite/bin/carbon-cache.py start --debug 2>&1

--- a/conf/etc/service/graphite/run
+++ b/conf/etc/service/graphite/run
@@ -19,11 +19,14 @@ if folder_empty /opt/graphite/storage; then
 	mkdir -p /opt/graphite/storage/whisper
 fi
 
+BIN=/opt/graphite/bin/python3
+[[ -f "/opt/graphite/bin/pypy3" ]] && BIN=/opt/graphite/bin/pypy3
+
 export PYTHONPATH=/opt/graphite/webapp
 export DJANGO_SETTINGS_MODULE=graphite.settings
-/opt/graphite/bin/django-admin.py makemigrations
-/opt/graphite/bin/django-admin.py migrate auth
-/opt/graphite/bin/django-admin.py migrate --run-syncdb
+${BIN} /opt/graphite/bin/django-admin.py makemigrations
+${BIN} /opt/graphite/bin/django-admin.py migrate auth
+${BIN} /opt/graphite/bin/django-admin.py migrate --run-syncdb
 /opt/graphite/bin/django_admin_init.sh || true
 
 if folder_empty /opt/graphite/webapp/graphite/functions/custom; then

--- a/conf/opt/graphite/bin/django_admin_init.sh
+++ b/conf/opt/graphite/bin/django_admin_init.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-cat <<EOF | python3 /opt/graphite/bin/django-admin.py shell
+BIN=/opt/graphite/bin/python3
+[[ -f "/opt/graphite/bin/pypy3" ]] && BIN=/opt/graphite/bin/pypy3
+
+cat <<EOF | ${BIN} /opt/graphite/bin/django-admin.py shell
 from django.contrib.auth import get_user_model
 
 User = get_user_model()  # get the currently active user model


### PR DESCRIPTION
Based on @Cactusbone's PR #151 

I didn't really like idea to migrate to pypy completely, but  I still want to have pypy as option.
I also didn't like idea to migrate to alpine-pypy image, because it's 1 man project and lagging behing  original alpine. 
Migrating back to `phusion` image will break ARM builds and cause Nginx  config incompatibilities again.
So, I decided to have hybrid approach - I will build two images, normal - with python3, for ARM and amd64, and pypy - based on alpine-pypy and for amd64 only. 
