### PR TITLE
Remove deprecated timeout switch

### DIFF
--- a/conf/entrypoint
+++ b/conf/entrypoint
@@ -23,7 +23,7 @@ shutdown() {
   echo "killing rest processes"
   # kill any other processes still running in the container
   for _pid  in $(ps -eo pid | grep -v PID  | tr -d ' ' | grep -v '^1$' | head -n -6); do
-    timeout -t 5 /bin/sh -c "kill $_pid && wait $_pid || kill -9 $_pid"
+    timeout 5 /bin/sh -c "kill $_pid && wait $_pid || kill -9 $_pid"
   done
   exit
 }


### PR DESCRIPTION
Timeout doesn't recognize the -t timeout switch anymore. Instead, the timeout duration is just the first parameter.

example log lines showing that timeout call errors:
```
Sep 06 11:32:33 hostname docker-carboncache[8812]: shutting down runsvdir
Sep 06 11:32:34 hostname docker-carboncache[8812]: killing rest processes
Sep 06 11:32:34 hostname docker-carboncache[8812]: timeout: unrecognized option: t
Sep 06 11:32:34 hostname docker-carboncache[8812]: BusyBox v1.32.1 () multi-call binary.
Sep 06 11:32:34 hostname docker-carboncache[8812]: Usage: timeout [-s SIG] SECS PROG ARGS
Sep 06 11:32:34 hostname docker-carboncache[8812]: Runs PROG. Sends SIG to it if it is not gone in SECS seconds.
Sep 06 11:32:34 hostname docker-carboncache[8812]: Default SIG: TERM.
```

timeout usage from within an alpine container:
```
/ # timeout
BusyBox v1.33.1 () multi-call binary.

Usage: timeout [-s SIG] SECS PROG ARGS

Run PROG. Send SIG to it if it is not gone in SECS seconds.
Default SIG: TERM.
```