### PR TITLE
Fix errors in logrotate runs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN true \
       /etc/nginx/conf.d/default.conf \
  && mkdir -p \
       /var/log/carbon \
-      /var/log/graphite
+      /var/log/graphite \
+ && touch /var/log/messages
 
 # optional packages (e.g. not exist on S390 in alpine 3.13 yet)
 RUN apk add --update \

--- a/conf/etc/logrotate.d/graphite-statsd
+++ b/conf/etc/logrotate.d/graphite-statsd
@@ -1,10 +1,8 @@
-/var/log/*.log /var/log/*/*.log {
+/var/log/*.log /var/log/carbon/*.log /var/log/graphite/*.log {
   daily
-  size 50M
   missingok
   rotate 14
   compress
-  delaycompress
   notifempty
   copytruncate
 }


### PR DESCRIPTION
With the current config, the following happens when running when the logrotate job runs:
```
$ docker run -d --name original graphiteapp/graphite-statsd:latest
91473a593cc7b338c24606c6763fade8c94dbdf344618963d8a11751879a3187
$ docker exec -it original /etc/periodic/daily/logrotate
error: nginx:1 duplicate log entry for /var/log/nginx/access.log
error: found error in file nginx, skipping
error: stat of /var/log/messages failed: No such file or directory
```
Additionally running logrotate with the verbose flag shows the following:
```
$ docker exec -it original /usr/sbin/logrotate -v /etc/logrotate.conf | grep warning
warning: 'size' overrides previously specified 'daily'
```

After these changes, there are no errors or warnings when running the periodic job. I didn't know which way to go with `daily` vs `size` but I personally prefer daily. I additionally removed `delaycompress` as logs can be quite large, but both of those last two choices are just opinions.