### PR TITLE
allow info performance logging toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_LOG_ROTATION_COUNT: (1) number of logs to keep (if GRAPHITE_LOG_ROTATION is true)
 * GRAPHITE_LOG_RENDERING_PERFORMANCE: (true) log performance information
 * GRAPHITE_LOG_CACHE_PERFORMANCE: (true) log cache performance information
+* GRAPHITE_LOG_INFO_PERFORMANCE: (false) log info performance information
 * GRAPHITE_LOG_FILE_INFO: (info.log), set to "-" for stdout/stderr
 * GRAPHITE_LOG_FILE_EXCEPTION: (exception.log), set to "-" for stdout/stderr
 * GRAPHITE_LOG_FILE_CACHE: (cache.log), set to "-" for stdout/stderr

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -36,6 +36,7 @@ LOG_ROTATION = os.environ.get("GRAPHITE_LOG_ROTATION", "false").lower() in ['1',
 LOG_ROTATION_COUNT = int(os.environ.get('GRAPHITE_LOG_ROTATION_COUNT', '1'))
 LOG_RENDERING_PERFORMANCE = os.environ.get("GRAPHITE_LOG_RENDERING_PERFORMANCE", "true").lower() in ['1', 'true', 'yes']
 LOG_CACHE_PERFORMANCE = os.environ.get("GRAPHITE_LOG_CACHE_PERFORMANCE", "true").lower() in ['1', 'true', 'yes']
+LOG_INFO_PERFORMANCE = os.environ.get("GRAPHITE_LOG_INFO_PERFORMANCE", "false").lower() in ['1', 'true', 'yes']
 
 # Filenames for log output, set to '-' to log to stderr
 LOG_FILE_INFO = os.environ.get("GRAPHITE_LOG_FILE_INFO", 'info.log')


### PR DESCRIPTION
Info performance logging is actually on by default and there is no proper toggle for that from the available environment variables. This adds the toggle and allows turning the noise off.