### PR TITLE
Unused settings cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,9 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_REPLICATION_FACTOR: (1) # The replication factor to use with consistent hashing. This should usually match the value configured in Carbon.
 * GRAPHITE_CLUSTER_SERVERS: ('') This should list of remote servers in the cluster. These servers must each have local access to metric data. Note that the first server to return a match for a query will be used. See [docs](https://graphite.readthedocs.io/en/latest/config-local-settings.html#cluster-configuration) for details.
 * GRAPHITE_USE_WORKER_POOL: (true) Creates a pool of worker threads to which tasks can be dispatched. This makes sense if there are multiple CLUSTER_SERVERS and/or STORAGE_FINDERS because then the communication with them can be parallelized.
-* GRAPHITE_POOL_WORKERS_PER_BACKEND: (8) The number of worker threads that should be created per backend server
-* GRAPHITE_POOL_WORKERS: (1) A baseline number of workers that should always be created
 * GRAPHITE_REMOTE_FIND_TIMEOUT: (30) Timeout for metric find requests
 * GRAPHITE_REMOTE_FETCH_TIMEOUT: (60) Timeout to fetch series data
 * GRAPHITE_REMOTE_RETRY_DELAY: (0) Time before retrying a failed remote webapp.
-* GRAPHITE_REMOTE_PREFETCH_DATA: (false) # set to True to fetch all metrics using a single http request per remote server instead of one http request per target, per remote server. # Especially useful when generating graphs with more than 4-5 targets or if there's significant latency between this server and the backends.
 * GRAPHITE_MAX_FETCH_RETRIES: (2) Number of retries for a specific remote data fetch
 * GRAPHITE_FIND_CACHE_DURATION: (0) Time to cache remote metric find results
 * GRAPHITE_STATSD_HOST: ("127.0.0.1") If set, django_statsd.middleware.GraphiteRequestTimingMiddleware and django_statsd.middleware.GraphiteMiddleware will be enabled.

--- a/conf/opt/graphite/webapp/graphite/local_settings.py
+++ b/conf/opt/graphite/webapp/graphite/local_settings.py
@@ -284,17 +284,6 @@ CLUSTER_SERVERS = [x for x in [host.strip() for host in os.environ.get('GRAPHITE
 # memory consumption (and number of connections to memcached).
 USE_WORKER_POOL = os.environ.get("GRAPHITE_USE_WORKER_POOL", "true").lower() in ['1', 'true', 'yes']
 
-# The number of worker threads that should be created per backend server.
-# It makes sense to have more than one thread per backend server if
-# the graphite-web web server itself is multi threaded and can handle multiple
-# incoming requests at once.
-POOL_WORKERS_PER_BACKEND = int(os.environ.get('GRAPHITE_POOL_WORKERS_PER_BACKEND', '8'))
-
-# A baseline number of workers that should always be created, no matter how many
-# cluster servers are configured. These are used for other tasks that can be
-# off-loaded from the request handling threads.
-POOL_WORKERS = int(os.environ.get('GRAPHITE_POOL_WORKERS', '1'))
-
 # Maximum number of worker threads for concurrent storage operations
 #POOL_MAX_WORKERS = 10
 
@@ -335,13 +324,6 @@ REMOTE_BUFFER_SIZE = int(os.environ.get('GRAPHITE_REMOTE_BUFFER_SIZE', '1048576'
 # Provide a list of HTTP headers that you want forwarded on from this host
 # when making a request to a remote webapp server in CLUSTER_SERVERS
 #REMOTE_STORE_FORWARD_HEADERS = [] # An iterable of HTTP header names
-
-## Prefetch cache
-# set to True to fetch all metrics using a single http request per remote server
-# instead of one http request per target, per remote server.
-# Especially useful when generating graphs with more than 4-5 targets or if
-# there's significant latency between this server and the backends.
-REMOTE_PREFETCH_DATA = os.environ.get("GRAPHITE_REMOTE_PREFETCH_DATA", "false").lower() in ['1', 'true', 'yes']
 
 ## Remote rendering settings
 # Set to True to enable rendering of Graphs on a remote webapp


### PR DESCRIPTION
Clean up some unused graphite-web Docker environment variables that do not currently exist in [graphite-web v1.1.10](https://github.com/graphite-project/graphite-web/tree/1.1.10)