### PR TITLE
Dockerfile Update to fix fadvise and rrdtool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,13 +73,12 @@ RUN true \
       django==4.2.15 \
       django-tagging==0.5.0 \
       django-statsd-mozilla \
-      fadvise \
       gunicorn==20.1.0 \
       eventlet>=0.24.1 \
       gevent>=1.4 \
       msgpack==0.6.2 \
       redis \
-      rrdtool \
+      rrdtool-bindings \
       python-ldap \
       mysqlclient \
       psycopg2==2.8.6 \


### PR DESCRIPTION
Latest image build is failing after the alpine image got updated recently.
fadvise is not getting installed due to incompatibility. Removing fadvise from dockerfile is fixes the error. 

rrdtool is not getting installed due to type mismatch in it's source code. 
rrdtool-bindings was introduced on PyPi as rrdtool stopped releasing latest versions after 2022 and for better compatibility with latest versions of Python.
rrdtool error is fixed after replacing it with rrdtool-bindings which provide similar functionality. 