### PR TITLE
Update health check to use wget instead of curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,4 +177,4 @@ STOPSIGNAL SIGHUP
 ENTRYPOINT ["/entrypoint"]
 
 HEALTHCHECK --interval=60s --start-interval=20s --timeout=3s \
-  CMD curl -f http://localhost/ || exit 1
+  CMD wget --quiet --spider http://127.0.0.1:80 || exit 1


### PR DESCRIPTION
Fix for #242 

Move healthcheck from using curl which is unavailable in the Alpine base image to wget

